### PR TITLE
feature: rework client which deals with release informations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
 
     // Misc
     implementation(platform(libs.mycelium.bom))
+    implementation(mn.micronaut.data.processor)
+    implementation(mn.micronaut.http.client)
     implementation(libs.bundles.vulpes)
     implementation(libs.jetbrains.annotation)
     implementation(libs.javapoet)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
 
     // Misc
     implementation(platform(libs.mycelium.bom))
-    implementation(mn.micronaut.data.processor)
     implementation(mn.micronaut.http.client)
     implementation(libs.bundles.vulpes)
     implementation(libs.jetbrains.annotation)

--- a/src/main/java/net/theevilreaper/vulpes/generator/controller/BuildInformationHandler.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/controller/BuildInformationHandler.java
@@ -10,19 +10,30 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.inject.Inject;
 import net.theevilreaper.vulpes.generator.domain.build.BuildInformationDTO;
+import net.theevilreaper.vulpes.generator.domain.client.GithubReleaseService;
+import net.theevilreaper.vulpes.generator.domain.release.GitReleaseDTO;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Controller("/build")
 public class BuildInformationHandler {
 
+    private final GithubReleaseService releaseService;
 
+    /**
+     * Creates a new instance of the {@link BuildInformationHandler}
+     *
+     * @param releaseService the {@link GithubReleaseService} to use for retrieving the latest release information.
+     */
     @Inject
-    public BuildInformationHandler() {
+    public BuildInformationHandler(GithubReleaseService releaseService) {
+        this.releaseService = releaseService;
     }
 
+    /**
+     * Returns the latest build information with a specific level of detail.
+     *
+     * @return the latest build information
+     */
     @Operation(
             summary = "Get build information",
             operationId = "getBuildData",
@@ -38,11 +49,11 @@ public class BuildInformationHandler {
             )
     )
     @Get(value = "/data", produces = MediaType.APPLICATION_JSON)
-    public @NotNull HttpResponse<BuildInformationDTO> getBuildInformation() {
-        //TODO: Reimplement it with Github integration
-        Map<String, String> data = new HashMap<>();
-        data.put("version", "1.0.0");
-        data.put("created", System.currentTimeMillis() + "");
-        return HttpResponse.ok(new BuildInformationDTO(data));
+    public @NotNull HttpResponse<GitReleaseDTO> getBuildInformation() {
+        GitReleaseDTO latestVersion = this.releaseService.getLatestVersion();
+        if (latestVersion == null) {
+            return HttpResponse.notFound();
+        }
+        return HttpResponse.ok(latestVersion);
     }
 }

--- a/src/main/java/net/theevilreaper/vulpes/generator/controller/BuildInformationHandler.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/controller/BuildInformationHandler.java
@@ -51,9 +51,6 @@ public class BuildInformationHandler {
     @Get(value = "/data", produces = MediaType.APPLICATION_JSON)
     public @NotNull HttpResponse<GitReleaseDTO> getBuildInformation() {
         GitReleaseDTO latestVersion = this.releaseService.getLatestVersion();
-        if (latestVersion == null) {
-            return HttpResponse.notFound();
-        }
         return HttpResponse.ok(latestVersion);
     }
 }

--- a/src/main/java/net/theevilreaper/vulpes/generator/controller/BuildInformationHandler.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/controller/BuildInformationHandler.java
@@ -4,6 +4,8 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,7 +24,8 @@ public class BuildInformationHandler {
     /**
      * Creates a new instance of the {@link BuildInformationHandler}
      *
-     * @param releaseService the {@link GithubReleaseService} to use for retrieving the latest release information.
+     * @param releaseService the {@link GithubReleaseService} to use for retrieving
+     *                       the latest release information.
      */
     @Inject
     public BuildInformationHandler(GithubReleaseService releaseService) {
@@ -49,6 +52,7 @@ public class BuildInformationHandler {
             )
     )
     @Get(value = "/data", produces = MediaType.APPLICATION_JSON)
+    @ExecuteOn(TaskExecutors.BLOCKING)
     public @NotNull HttpResponse<GitReleaseDTO> getBuildInformation() {
         GitReleaseDTO latestVersion = this.releaseService.getLatestVersion();
         return HttpResponse.ok(latestVersion);

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubBuildClient.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubBuildClient.java
@@ -1,6 +1,7 @@
 package net.theevilreaper.vulpes.generator.domain.client;
 
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
 import io.micronaut.http.client.annotation.Client;
 import net.theevilreaper.vulpes.generator.domain.release.GitTag;
 import net.theevilreaper.vulpes.generator.domain.release.GitRelease;
@@ -8,7 +9,8 @@ import net.theevilreaper.vulpes.generator.domain.release.GitRelease;
 import java.util.List;
 
 /**
- * The intention behind the {@link GithubBuildClient} is to provide method endpoints to fetch some specific
+ * The intention behind the {@link GithubBuildClient} is to provide method
+ * endpoints to fetch some specific
  * release data from a Github repository.
  *
  * @author theEvilReaper
@@ -16,6 +18,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @Client("github")
+@Header(name = "User-Agent", value = "Vulpes-Generator")
 public interface GithubBuildClient {
 
     /**

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubBuildClient.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubBuildClient.java
@@ -7,6 +7,14 @@ import net.theevilreaper.vulpes.generator.domain.release.GitRelease;
 
 import java.util.List;
 
+/**
+ * The intention behind the {@link GithubBuildClient} is to provide method endpoints to fetch some specific
+ * release data from a Github repository.
+ *
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 1.0.0
+ */
 @Client("github")
 public interface GithubBuildClient {
 

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubBuildClient.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubBuildClient.java
@@ -1,0 +1,32 @@
+package net.theevilreaper.vulpes.generator.domain.client;
+
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.annotation.Client;
+import net.theevilreaper.vulpes.generator.domain.release.GitTag;
+import net.theevilreaper.vulpes.generator.domain.release.GitRelease;
+
+import java.util.List;
+
+@Client("github")
+public interface GithubBuildClient {
+
+    /**
+     * Returns the latest release for the given repository
+     *
+     * @param owner the owner of the repository
+     * @param repo  the repository name
+     * @return the latest release as {@link GitRelease}
+     */
+    @Get("/repos/{owner}/{repo}/releases/latest")
+    GitRelease latestRelease(String owner, String repo);
+
+    /**
+     * Returns all tags for the given repository
+     *
+     * @param owner the owner of the repository
+     * @param repo  the repository name
+     * @return a list of tags
+     */
+    @Get("/repos/{owner}/{repo}/tags")
+    List<GitTag> tags(String owner, String repo);
+}

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseService.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseService.java
@@ -41,7 +41,6 @@ public class GithubReleaseService {
             );
 
             return GitReleaseDTO.fromRelease(release);
-
         } catch (HttpClientResponseException _) {
             return fallbackToTags();
         }

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseService.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseService.java
@@ -19,8 +19,10 @@ public class GithubReleaseService {
     /**
      * Creates a new instance of the {@link GithubReleaseService}
      *
-     * @param client the {@link GithubBuildClient} to use for retrieving the latest release information.
-     * @param config the {@link GithubConfiguration} to use for retrieving the repository information.
+     * @param client the {@link GithubBuildClient} to use for retrieving the latest
+     *               release information.
+     * @param config the {@link GithubConfiguration} to use for retrieving the
+     *               repository information.
      */
     @Inject
     public GithubReleaseService(GithubBuildClient client, GithubConfiguration config) {
@@ -39,7 +41,9 @@ public class GithubReleaseService {
                     config.owner(),
                     config.repo()
             );
-
+            if (release == null) {
+                return fallbackToTags();
+            }
             return GitReleaseDTO.fromRelease(release);
         } catch (HttpClientResponseException _) {
             return fallbackToTags();

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseService.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseService.java
@@ -6,6 +6,9 @@ import jakarta.inject.Singleton;
 import net.theevilreaper.vulpes.generator.domain.configuration.GithubConfiguration;
 import net.theevilreaper.vulpes.generator.domain.release.GitReleaseDTO;
 import net.theevilreaper.vulpes.generator.domain.release.GitRelease;
+import net.theevilreaper.vulpes.generator.domain.release.GitTag;
+
+import java.util.List;
 
 @Singleton
 public class GithubReleaseService {
@@ -13,12 +16,23 @@ public class GithubReleaseService {
     private final GithubBuildClient client;
     private final GithubConfiguration config;
 
+    /**
+     * Creates a new instance of the {@link GithubReleaseService}
+     *
+     * @param client the {@link GithubBuildClient} to use for retrieving the latest release information.
+     * @param config the {@link GithubConfiguration} to use for retrieving the repository information.
+     */
     @Inject
     public GithubReleaseService(GithubBuildClient client, GithubConfiguration config) {
         this.client = client;
         this.config = config;
     }
 
+    /**
+     * Returns the latest release information from the Github repository.
+     *
+     * @return the latest release information
+     */
     public GitReleaseDTO getLatestVersion() {
         try {
             GitRelease release = client.latestRelease(
@@ -33,13 +47,13 @@ public class GithubReleaseService {
         }
     }
 
+    /**
+     * Fallback method to get the latest tag if no releases are found
+     *
+     * @return the latest tag
+     */
     private GitReleaseDTO fallbackToTags() {
-        var tags = client.tags(config.owner(), config.repo());
-
-        if (tags.isEmpty()) {
-            return GitReleaseDTO.unknown();
-        }
-
-        return GitReleaseDTO.fromTag(tags.getFirst().name());
+        List<GitTag> tags = client.tags(config.owner(), config.repo());
+        return tags.isEmpty() ? GitReleaseDTO.unknown() : GitReleaseDTO.fromTag(tags.getFirst().name());
     }
 }

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseService.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseService.java
@@ -1,0 +1,45 @@
+package net.theevilreaper.vulpes.generator.domain.client;
+
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import net.theevilreaper.vulpes.generator.domain.configuration.GithubConfiguration;
+import net.theevilreaper.vulpes.generator.domain.release.GitReleaseDTO;
+import net.theevilreaper.vulpes.generator.domain.release.GitRelease;
+
+@Singleton
+public class GithubReleaseService {
+
+    private final GithubBuildClient client;
+    private final GithubConfiguration config;
+
+    @Inject
+    public GithubReleaseService(GithubBuildClient client, GithubConfiguration config) {
+        this.client = client;
+        this.config = config;
+    }
+
+    public GitReleaseDTO getLatestVersion() {
+        try {
+            GitRelease release = client.latestRelease(
+                    config.owner(),
+                    config.repo()
+            );
+
+            return GitReleaseDTO.fromRelease(release);
+
+        } catch (HttpClientResponseException _) {
+            return fallbackToTags();
+        }
+    }
+
+    private GitReleaseDTO fallbackToTags() {
+        var tags = client.tags(config.owner(), config.repo());
+
+        if (tags.isEmpty()) {
+            return GitReleaseDTO.unknown();
+        }
+
+        return GitReleaseDTO.fromTag(tags.getFirst().name());
+    }
+}

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/configuration/GithubConfiguration.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/configuration/GithubConfiguration.java
@@ -1,0 +1,10 @@
+package net.theevilreaper.vulpes.generator.domain.configuration;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+@ConfigurationProperties("github")
+public record GithubConfiguration(
+        String owner,
+        String repo
+) {
+}

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/configuration/GithubConfiguration.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/configuration/GithubConfiguration.java
@@ -2,6 +2,16 @@ package net.theevilreaper.vulpes.generator.domain.configuration;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 
+/**
+ * Configuration which is required to communicate with Github to retrieve release information
+ * over the {@link net.theevilreaper.vulpes.generator.domain.client.GithubBuildClient}.
+ *
+ * @param owner the owner / organization of the repository
+ * @param repo  the repository name
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 1.0.0
+ */
 @ConfigurationProperties("github")
 public record GithubConfiguration(
         String owner,

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitRelease.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitRelease.java
@@ -12,6 +12,9 @@ import java.time.OffsetDateTime;
  * @param name        the name of the release
  * @param htmlUrl     the url to the release on github
  * @param publishedAt the date when the release was published
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 1.0.0
  */
 @Serdeable
 public record GitRelease(

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitRelease.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitRelease.java
@@ -1,0 +1,27 @@
+package net.theevilreaper.vulpes.generator.domain.release;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.time.OffsetDateTime;
+
+/**
+ * The class represents a Github Release pojo object.
+ *
+ * @param tagName     the tag name of the release
+ * @param name        the name of the release
+ * @param htmlUrl     the url to the release on github
+ * @param publishedAt the date when the release was published
+ */
+@Serdeable
+public record GitRelease(
+        @JsonProperty("tag_name")
+        String tagName,
+        String name,
+        @JsonProperty("html_url")
+        String htmlUrl,
+        @JsonProperty("published_at")
+        OffsetDateTime publishedAt
+) {
+
+}

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitReleaseDTO.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitReleaseDTO.java
@@ -1,0 +1,45 @@
+package net.theevilreaper.vulpes.generator.domain.release;
+
+import java.time.OffsetDateTime;
+
+public class GitReleaseDTO {
+
+    private final String version;
+    private final String url;
+    private final OffsetDateTime publishedAt;
+
+    private GitReleaseDTO(String version, String url, OffsetDateTime publishedAt) {
+        this.version = version;
+        this.url = url;
+        this.publishedAt = publishedAt;
+    }
+
+    public static GitReleaseDTO fromRelease(GitRelease release) {
+        return new GitReleaseDTO(
+                release.tagName(),
+                release.htmlUrl(),
+                release.publishedAt()
+        );
+    }
+
+    public static GitReleaseDTO fromTag(String tag) {
+        return new GitReleaseDTO(tag, null, null);
+    }
+
+    public static GitReleaseDTO unknown() {
+        return new GitReleaseDTO("unknown", null, null);
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public OffsetDateTime getPublishedAt() {
+        return publishedAt;
+    }
+}
+

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitReleaseDTO.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitReleaseDTO.java
@@ -1,19 +1,32 @@
 package net.theevilreaper.vulpes.generator.domain.release;
 
+import io.micronaut.serde.annotation.Serdeable;
+
 import java.time.OffsetDateTime;
 
-public class GitReleaseDTO {
+/**
+ * The {@link GitReleaseDTO} is a data transfer object which is sent via API to inform clients about the new release
+ *
+ * @param version     the version of the release
+ * @param url         the url to the release on Github
+ * @param publishedAt the date when the release was published
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+@Serdeable
+public record GitReleaseDTO(
+        String version,
+        String url,
+        OffsetDateTime publishedAt
+) {
 
-    private final String version;
-    private final String url;
-    private final OffsetDateTime publishedAt;
-
-    private GitReleaseDTO(String version, String url, OffsetDateTime publishedAt) {
-        this.version = version;
-        this.url = url;
-        this.publishedAt = publishedAt;
-    }
-
+    /**
+     * Creates a new release dto from a given release object
+     *
+     * @param release the release to create the dto from
+     * @return the created {@link GitReleaseDTO} instance
+     */
     public static GitReleaseDTO fromRelease(GitRelease release) {
         return new GitReleaseDTO(
                 release.tagName(),
@@ -22,24 +35,22 @@ public class GitReleaseDTO {
         );
     }
 
+    /**
+     * Creates a new release dto from a given tag
+     *
+     * @param tag the tag to create the dto from
+     * @return the created {@link GitReleaseDTO} instance
+     */
     public static GitReleaseDTO fromTag(String tag) {
         return new GitReleaseDTO(tag, null, null);
     }
 
+    /**
+     * Creates a new unknown release dto
+     *
+     * @return the created {@link GitReleaseDTO} instance
+     */
     public static GitReleaseDTO unknown() {
         return new GitReleaseDTO("unknown", null, null);
     }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public OffsetDateTime getPublishedAt() {
-        return publishedAt;
-    }
 }
-

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitTag.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitTag.java
@@ -2,6 +2,14 @@ package net.theevilreaper.vulpes.generator.domain.release;
 
 import io.micronaut.serde.annotation.Serdeable;
 
+/**
+ * Simple pojo class to represent a Git Tag
+ *
+ * @param name the name of the tag
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 1.0.0
+ */
 @Serdeable
 public record GitTag(String name) {
 }

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitTag.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitTag.java
@@ -1,0 +1,7 @@
+package net.theevilreaper.vulpes.generator.domain.release;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record GitTag(String name) {
+}

--- a/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitTag.java
+++ b/src/main/java/net/theevilreaper/vulpes/generator/domain/release/GitTag.java
@@ -12,4 +12,10 @@ import io.micronaut.serde.annotation.Serdeable;
  */
 @Serdeable
 public record GitTag(String name) {
+
+    public GitTag {
+        if (name == null) {
+            name = "Unknown";
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ micronaut:
       github:
         url: https://api.github.com
         connect-timeout: 2s
-        read-timeout: 5s
+        read-timeout: 30s
   router:
     static-resources:
       swagger:

--- a/src/test/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseServiceTest.java
+++ b/src/test/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseServiceTest.java
@@ -1,0 +1,76 @@
+package net.theevilreaper.vulpes.generator.domain.client;
+
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import net.theevilreaper.vulpes.generator.domain.configuration.GithubConfiguration;
+import net.theevilreaper.vulpes.generator.domain.release.GitRelease;
+import net.theevilreaper.vulpes.generator.domain.release.GitReleaseDTO;
+import net.theevilreaper.vulpes.generator.domain.release.GitTag;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GithubReleaseServiceTest {
+
+    @Mock
+    GithubBuildClient client;
+
+    @Mock
+    GithubConfiguration config;
+
+    GithubReleaseService service;
+
+    @BeforeEach
+    void setUp() {
+        when(config.owner()).thenReturn("owner");
+        when(config.repo()).thenReturn("repo");
+
+        service = new GithubReleaseService(client, config);
+    }
+
+    @Test
+    void returnsLatestReleaseWhenAvailable() {
+        GitRelease release = mock(GitRelease.class);
+
+        when(client.latestRelease("owner", "repo"))
+                .thenReturn(release);
+
+        GitReleaseDTO dto = service.getLatestVersion();
+
+        assertEquals(dto, GitReleaseDTO.fromRelease(release));
+        verify(client, never()).tags(any(), any());
+    }
+
+    @Test
+    void fallsBackToTagsWhenReleaseFails() {
+        when(client.latestRelease("owner", "repo"))
+                .thenThrow(mock(HttpClientResponseException.class));
+
+        GitTag tag = new GitTag("v1.2.3");
+        when(client.tags("owner", "repo"))
+                .thenReturn(List.of(tag));
+
+        GitReleaseDTO dto = service.getLatestVersion();
+        assertEquals(dto, GitReleaseDTO.fromTag("v1.2.3"));
+    }
+
+    @Test
+    void returnsUnknownWhenNoReleaseAndNoTags() {
+        when(client.latestRelease("owner", "repo"))
+                .thenThrow(mock(HttpClientResponseException.class));
+
+        when(client.tags("owner", "repo"))
+                .thenReturn(List.of());
+
+        GitReleaseDTO dto = service.getLatestVersion();
+
+        assertEquals(dto, GitReleaseDTO.unknown());
+    }
+}

--- a/src/test/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseServiceTest.java
+++ b/src/test/java/net/theevilreaper/vulpes/generator/domain/client/GithubReleaseServiceTest.java
@@ -49,6 +49,19 @@ class GithubReleaseServiceTest {
     }
 
     @Test
+    void fallsBackToTagsWhenReleaseIsNull() {
+        when(client.latestRelease("owner", "repo"))
+                .thenReturn(null);
+
+        GitTag tag = new GitTag("v1.2.3");
+        when(client.tags("owner", "repo"))
+                .thenReturn(List.of(tag));
+
+        GitReleaseDTO dto = service.getLatestVersion();
+        assertEquals(dto, GitReleaseDTO.fromTag("v1.2.3"));
+    }
+
+    @Test
     void fallsBackToTagsWhenReleaseFails() {
         when(client.latestRelease("owner", "repo"))
                 .thenThrow(mock(HttpClientResponseException.class));

--- a/src/test/java/net/theevilreaper/vulpes/generator/domain/release/GitTagTest.java
+++ b/src/test/java/net/theevilreaper/vulpes/generator/domain/release/GitTagTest.java
@@ -1,0 +1,22 @@
+package net.theevilreaper.vulpes.generator.domain.release;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GitTagTest {
+
+    @Test
+    void testEmptyGitTag() {
+        GitTag tag = new GitTag(null);
+        assertNotNull(tag);
+        assertEquals("Unknown", tag.name());
+    }
+
+    @Test
+    void testSimpleGitTag() {
+        GitTag tag = new GitTag("1.0.0");
+        assertNotNull(tag);
+        assertEquals("1.0.0", tag.name());
+    }
+}


### PR DESCRIPTION
## Proposed changes

The generator backend provides an endpoint to retrieve release information for the base project. Due to the migration from GitLab to Gradle, this feature became broken. This pull request updates its usage and introduces a new approach that works with GitHub.

The solution is based on a generated Micronaut client that performs the calls and transforms the data into different objects. If a project has no release, it checks for tags, and if no data is present, it uses default values to prevent issues.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)