### PR TITLE
feat(observability): JSON/Loki logging + OpenTelemetry tracing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,17 @@ dependencies {
 
     // Logging
     implementation(mn.logback.classic)
+    // Distributed tracing (OpenTelemetry). Spans/export are only active when
+    // OTEL_TRACES_EXPORTER=otlp is set (prod/Docker) — see application.yml.
+    implementation(mn.micronaut.tracing.opentelemetry.http)
+    implementation(mn.micronaut.tracing.opentelemetry.jdbc)
+    implementation(libs.opentelemetry.exporter.otlp)
+    // Structured JSON logging for Grafana Loki + trace/log correlation.
+    // logstash encoder renders JSON; the OTel MDC appender injects trace_id/span_id.
+    implementation(libs.logstash.logback.encoder)
+    implementation(libs.opentelemetry.logback.mdc)
+    // Enables the <if>/<then>/<else> conditional in logback.xml.
+    runtimeOnly(libs.janino)
 
     implementation(mn.micronaut.openapi)
     implementation(mn.swagger.core)
@@ -125,7 +136,9 @@ micronaut {
         optimizeClassLoading = false
         deduceEnvironment = true
         optimizeNetty = true
-        replaceLogbackXml = true
+        // Keep logback.xml parsed at runtime so its <if> JSON/plain switch and the
+        // OpenTelemetry MDC appender work (AOT replacement would inline a static config).
+        replaceLogbackXml = false
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,6 +40,9 @@ dependencyResolutionManagement {
             version("guava", "33.6.0-jre")
             version("commons.io", "2.22.0")
             version("commons.compress", "1.28.0")
+            version("logstash.logback.encoder", "8.1")
+            version("janino", "3.1.12")
+            version("opentelemetry.instrumentation.alpha", "2.20.1-alpha")
 
             library("mycelium.bom", "net.onelitefeather", "mycelium-bom").versionRef("mycelium")
 
@@ -53,6 +56,13 @@ dependencyResolutionManagement {
             library("guava", "com.google.guava", "guava").versionRef("guava")
             library("commons.io", "commons-io", "commons-io").versionRef("commons.io")
             library("commons.compress", "org.apache.commons", "commons-compress").versionRef("commons.compress")
+
+            // Observability — JSON logging + OpenTelemetry (see build.gradle.kts).
+            // OTLP exporter version is managed by the Micronaut platform BOM.
+            library("logstash.logback.encoder", "net.logstash.logback", "logstash-logback-encoder").versionRef("logstash.logback.encoder")
+            library("janino", "org.codehaus.janino", "janino").versionRef("janino")
+            library("opentelemetry.exporter.otlp", "io.opentelemetry", "opentelemetry-exporter-otlp").withoutVersion()
+            library("opentelemetry.logback.mdc", "io.opentelemetry.instrumentation", "opentelemetry-logback-mdc-1.0").versionRef("opentelemetry.instrumentation.alpha")
 
             plugin("micronaut.application", "io.micronaut.application").versionRef("micronaut")
             plugin("micronaut.aot", "io.micronaut.aot").versionRef("micronaut")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,3 +59,25 @@ github:
   clone-url: ${GITHUB_CLONE_URL:https://github.com/OneLiteFeatherNET/vulpes-base.git}
   username: ${GITHUB_USERNAME:vulpes}
   password: ${GITHUB_PASSWORD:}
+
+# OpenTelemetry — tracing is disabled unless OTEL_TRACES_EXPORTER=otlp is set
+# (do this in the Docker/prod container). HTTP (server/client) and JDBC spans
+# are instrumented automatically once enabled.
+otel:
+  service:
+    name: ${OTEL_SERVICE_NAME:vulpes-generator}
+  traces:
+    exporter: ${OTEL_TRACES_EXPORTER:none}
+  metrics:
+    exporter: none
+  logs:
+    exporter: none
+  exporter:
+    otlp:
+      protocol: grpc
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:`http://localhost:4317`}
+  exclusions:
+    - /swagger
+    - /swagger/.*
+    - /swagger-ui
+    - /swagger-ui/.*

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,14 +1,40 @@
 <configuration>
+    <!--
+      Logging is human-readable by default (local dev) and switches to structured
+      JSON on stdout when LOG_JSON=true (set this in the Docker/prod container) so
+      Grafana Loki can index the fields. The OpenTelemetry MDC appender injects
+      trace_id/span_id/trace_flags into the MDC for log <-> trace correlation.
+    -->
+    <property name="LOG_JSON" value="${LOG_JSON:-false}"/>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-        <encoder>
-            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
-        </encoder>
+    <if condition='"true".equalsIgnoreCase(property("LOG_JSON"))'>
+        <then>
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <fieldNames>
+                        <timestamp>timestamp</timestamp>
+                        <message>message</message>
+                        <logger>logger</logger>
+                        <thread>thread</thread>
+                        <level>level</level>
+                    </fieldNames>
+                </encoder>
+            </appender>
+        </then>
+        <else>
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                    <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+                </encoder>
+            </appender>
+        </else>
+    </if>
+
+    <appender name="OTEL" class="io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender">
+        <appender-ref ref="STDOUT"/>
     </appender>
 
-    <root level="info">
-        <appender-ref ref="STDOUT" />
+    <root level="INFO">
+        <appender-ref ref="OTEL"/>
     </root>
 </configuration>


### PR DESCRIPTION
Adds the observability setup that was authored alongside #117 but did not make it onto `main` (only the release/Docker commit was merged). Cherry-picked cleanly onto current `main`.

Mirrors Vulpes-Backend.

## Logging (Grafana Loki)
- `logback.xml`: human-readable locally; **JSON on stdout when `LOG_JSON=true`** (logstash encoder) so Loki can index fields.
- OpenTelemetry MDC appender injects `trace_id`/`span_id`/`trace_flags` for log ↔ trace correlation.
- Janino (`runtimeOnly`) enables the `<if>`/`<then>`/`<else>` switch.

## Tracing (OpenTelemetry)
- `micronaut-tracing-opentelemetry-http` + `-jdbc` + OTLP exporter — the generator serves HTTP (GitHub client, swagger) and uses JDBC, so both are instrumented.
- Inert by default (`OTEL_TRACES_EXPORTER=none`); enable via env in prod/Docker.
- `application.yml` `otel` block (service name `vulpes-generator`, OTLP endpoint, swagger span exclusions).

## Build
- Version-catalog entries for the new libs.
- AOT `replaceLogbackXml = false` so the conditional logback config is parsed at runtime.

Independent of other PRs (the shared `@v2.3.0` workflows and the release/Docker setup are already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)