### PR TITLE
fix(publish): publish only the thin jar (dist artifacts exceed repo limit)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,12 +144,11 @@ micronaut {
 
 publishing {
     publications.create<MavenPublication>("maven") {
-        artifact(project.tasks.optimizedJitJar)
-        artifact(project.tasks.optimizedRunnerJitJar)
-        artifact(project.tasks.runnerJar)
+        // Only the thin application jar is published. The fat runner jars and the
+        // full distribution tar/zip bundle every dependency and exceed the Maven
+        // repository's upload size limit (HTTP 413). The runnable artifact is the
+        // Docker image, not a Maven artifact.
         artifact(project.tasks.jar)
-        artifact(project.tasks.optimizedDistTar)
-        artifact(project.tasks.optimizedDistZip)
 
         version = rootProject.version as String
         artifactId = "vulpes-generator"


### PR DESCRIPTION
The `0.1.0` release (and every snapshot push) failed the **Maven publish** job:

```
Could not PUT '…/vulpes-generator-0.1.0.tar' — 413 Payload Too Large
```

The publication uploaded `optimizedDistTar` / `optimizedDistZip` (+ fat runner jars), which bundle every dependency (minestom, jgit, guava, …) and exceed the Maven repository's upload size limit. (Backend publishes the same artifacts, but they're small enough there.)

## Fix
Publish only the thin `jar` (+ pom). The runnable deliverable is the Docker image, not a Maven artifact.

## Note — separate Docker failure (not this PR)
The `docker` job fails independently with `404 failed to send blob (chunk)` for `onelitefeather/vulpes-generator`. The producer build succeeds; the registry rejects the push. Since backend/otis push fine to the same `onelitefeather` Harbor project, this is a **registry-side** issue — the `vulpes-generator` repository must be created in Harbor (or the push robot granted write access). After that, re-run via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)